### PR TITLE
Add secondary selectors for selectors including tbody tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,11 @@ module.exports = function Selector(elements) {
             remaining = filtered;
         }
 
-        return selectors.map(function(selector) {
-            return ancestorSelector + ' ' + selector;
-        }).join(", \n").trim();
+        return selectors
+            .map(function(selector) {
+                return SelectorUtils.makeTbodyOptional(ancestorSelector + ' ' + selector);
+            })
+            .join(", \n")
+            .trim();
     }
 }

--- a/selector-utils.js
+++ b/selector-utils.js
@@ -41,5 +41,18 @@ module.exports = {
         }
 
         return null;
+    },
+
+    /**
+     * Transform a CSS selector to work in environments where <tbody> elements may not be added to the DOM automatically
+     *
+     * @return {String}
+     */
+    'makeTbodyOptional' : function(selector) {
+        if(/\s+tbody/.test(selector)) {
+            return selector + ', \n' + selector.replace(/(\s+)tbody.*?\>\s+/g, '$1');
+        } else {
+            return selector
+        }
     }
 }

--- a/selector-utils.js
+++ b/selector-utils.js
@@ -50,7 +50,7 @@ module.exports = {
      */
     'makeTbodyOptional' : function(selector) {
         if(/\s+tbody/.test(selector)) {
-            return selector + ', \n' + selector.replace(/(\s+)tbody.*?\>\s+/g, '$1');
+            return selector + ', \n' + selector.replace(/(\s+|^)tbody.*?\>\s+/g, '$1');
         } else {
             return selector
         }


### PR DESCRIPTION
- For every selector that contains a tbody tag, a secondary selector is now appended that has that tag removed.
- **Note:** This could still potentially fail to generate reusable selectors on very specific DOM structures where some tables include a tbody tag and others do not.

A resulting selector might look like:

``` css
table:nth-child(8) > tbody:nth-child(1) > tr:nth-child(4) td.formFieldNormal.top:nth-child(2) > b:nth-child(1), 
table:nth-child(8) > tr:nth-child(4) td.formFieldNormal.top:nth-child(2) > b:nth-child(1), 
table:nth-child(8) > tbody:nth-child(1) > tr:nth-child(4) td.nowrapFormLabel.width160.top:nth-child(1), 
table:nth-child(8) > tr:nth-child(4) td.nowrapFormLabel.width160.top:nth-child(1)
```
